### PR TITLE
Update geom-ribbon.R

### DIFF
--- a/R/geom-ribbon.R
+++ b/R/geom-ribbon.R
@@ -156,6 +156,7 @@ GeomRibbonPattern <- ggproto(
       outline.type,
       both = munched_lines$id + rep(c(0, max(ids, na.rm = TRUE)), each = length(ids)),
       upper = munched_lines$id + rep(c(0, NA), each = length(ids)),
+      none = munched_lines$id + rep(c(NA, NA), each = length(ids)),
       abort(glue("invalid outline.type: {outline.type}"))
     )
     g_lines <- polylineGrob(
@@ -184,7 +185,7 @@ geom_area_pattern <- function(mapping = NULL, data = NULL, stat = "identity",
                               position = "stack", na.rm = FALSE, orientation = NA,
                               show.legend = NA, inherit.aes = TRUE, ...,
                               outline.type = "upper") {
-  outline.type <- match.arg(outline.type, c("both", "upper", "legacy"))
+  outline.type <- match.arg(outline.type, c("both", "upper", "legacy", "none"))
 
   layer(
     data = data,


### PR DESCRIPTION
In the case that you create a plot with geom_line that has specific line types (solid, dashed, dotted) etc, and you want to add a geom_area_pattern/ribbon then the part with the pattern overlay will have a newly drawn line without the original line type (dashed, dotted). Hence, you will have a plot where the line is dotted except for the part that has a pattern overlay, there the line is solid. This can be fixed in an easy way by not drawing any lines in the area that contains the pattern. However, this option was not available, hence I added the following to the package to add this feature. I have to admit that I didn't do any extensive testing, but I think this feature could be useful for a broader audience. 