### PR TITLE
fix: Prevent build time dependency on 'memoise'

### DIFF
--- a/R/utils-magick-read.R
+++ b/R/utils-magick-read.R
@@ -29,9 +29,6 @@ img_read <- function(filename) {
   img
 }
 
-
-img_read_memoised <- memoise::memoise(img_read)
-
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #' Fetch a given path or URL as a 3D RGB array of values
 #'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,13 @@
+# We use `<<-` below to modify the package's namespace
+# in order to prevent build time dependencies on `memoise`
+# as recommended in <http://memoise.r-lib.org/reference/memoise.html#details>.
+# We don't modify the global environment.
+# See <https://github.com/r-lib/memoise/issues/76> for further details.
+
+# Define function at build time
+img_read_memoised <- img_read
+
+# Modify function at load time
+.onLoad <- function(libname, pkgname) {
+    img_read_memoised <<- memoise::memoise(img_read)
+}


### PR DESCRIPTION
* In order to prevent build time dependency on 'memoise'
  we define `img_read_memoised()` at build time
  and then replace it at load time with a
  memoised version within `.onLoad()`
* This is recommended in <http://memoise.r-lib.org/reference/memoise.html#details>
* See <https://github.com/r-lib/memoise/issues/76> for further details
* On some platforms doing this also prevents an R CMD check NOTE