### PR TITLE
CRAN release v1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggpattern
 Type: Package
 Title: 'ggplot2' Pattern Geoms
-Version: 0.4.3-3
+Version: 1.0.0
 Authors@R: c(person("Mike", "FC", role = "aut",
                     email = "mikefc@coolbutuseless.com"),
              person("Trevor L", "Davis", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Version: 1.0.0
 Authors@R: c(person("Mike", "FC", role = "aut",
                     email = "mikefc@coolbutuseless.com"),
              person("Trevor L", "Davis", role = c("aut", "cre"),
-                    email = "trevor.l.davis@gmail.com"),
+                    email = "trevor.l.davis@gmail.com",
+                    comment = c(ORCID = "0000-0001-6341-4639")),
              person("ggplot2 authors", role = "aut"))
 Description: Provides 'ggplot2' geoms filled with various patterns.  Includes a patterned version of every 'ggplot2' geom that has a region that can be filled with a pattern.  Provides a suite of 'ggplot2' aesthetics and scales for controlling pattern appearances.  Supports over a dozen builtin patterns (every pattern implemented by 'gridpattern') as well as allowing custom user-defined patterns.
 URL: https://github.com/coolbutuseless/ggpattern, https://coolbutuseless.github.io/package/ggpattern/index.html 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ggpattern 0.4.3
+# ggpattern 1.0.0
 
 ## Bug fixes and minor improvements
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,30 +1,15 @@
-As requested by Dr. Uwe Ligges I have reduced the size of the package tarball
-under 5 MB by omitting the package (visual) unit tests 
-and omitting seven package vignettes.
+In under to keep the package tarball
+under 5 MB we omit the package (visual) unit tests 
+and we omit seven package vignettes.
 
 ## Test environments
 
 * win-builder (windows, R devel)
 * mac-builder (macosx, R release)
-* local (linux, R 4.1.2)
+* local (linux, R 4.2.1)
 * github actions (linux, R release)
 * github actions (linux, R devel)
 
 ## R CMD check --as-cran results
 
-2 NOTES
-
-```
-New submission
-```
-
-This is a new submission
-
-```
-Possibly misspelled words in DESCRIPTION:
-  Geoms (3:26)
-  geoms (10:33)
-```
-
-"geoms" is not misspelled.  Other CRAN packages such as {ggforce} 
-use it in their DESCRIPTION without quotes.
+OK

--- a/vignettes/developing-patterns.Rmd
+++ b/vignettes/developing-patterns.Rmd
@@ -231,8 +231,10 @@ df <- data.frame(trt = c("a", "b", "c"), outcome = c(2.3, 1.9, 3.2))
 ggplot(df, aes(trt, outcome)) +
     geom_col_pattern(aes(fill = trt), colour = 'black', 
                      pattern = 'multicolor_stripe',
-                     pattern_fill = "grey30,grey70,white,grey70") +
-    theme(legend.key.size = unit(1.5, 'cm'))
+                     pattern_fill = "grey30,grey70,white,grey70",
+                     pattern_density = 0.2,
+                     pattern_spacing = 0.1) +
+    theme(legend.key.size = unit(1.2, 'cm'))
 ```
 
 <a name="geometry-example-2"></a> Example: Three-color polygon tilings (adapting `{ggplot2}` aesthetics)
@@ -287,10 +289,12 @@ options(ggpattern_geometry_funcs = list(tiling3 = tiling3_pattern))
 ```{r}
 df <- data.frame(trt = c("a", "b", "c"), outcome = c(2.3, 1.9, 3.2))
 ggplot(df, aes(trt, outcome)) +
-    geom_col_pattern(aes(fill = trt, pattern_type = trt), 
-                     pattern = 'tiling3', pattern_angle = 45) +
+    geom_col_pattern(aes(fill = trt, pattern_type = trt),
+                     pattern = 'tiling3',
+                     pattern_angle = 45,
+                     pattern_spacing = 0.15) +
     scale_pattern_type_manual(values = c("hexagonal", "tetrakis_square", "rhombille")) +
-    theme(legend.key.size = unit(1.5, 'cm'))
+    theme(legend.key.size = unit(1.2, 'cm'))
 ```
 
 <a name="other-example"></a> Other examples


### PR DESCRIPTION
* We'll release a new version of `{ggpattern}` to CRAN by the end of the month (#87)
* Bump version number to v1.0 to reflect the API is stable (#78) (barring any breaking upstream changes in `{ggplot2}`)
* Change `pattern_spacing` and `pattern_density` in "Developing patterns" vignette 
  so it looks better in CRAN version of vignette 
 (smaller image sizes than pkgdown version)
* When I build the package tarball for release I'll temporarily (and locally) replace `.Rbuildignore` with `.Rbuildignore_CRAN` to shrink the package size to within CRAN limitations
* Unsure if `{ggplot2}` will be released in time to meet CRAN's deadline to incorporate #84 

closes #78, closes #87