### PR TITLE
feat: Add `guide` argument to several scales

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggpattern
 Type: Package
 Title: 'ggplot2' Pattern Geoms
-Version: 1.1.5-3
+Version: 1.2.0-1
 Authors@R: c(person("Mike", "FC", role = "aut"),
              person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# ggpattern 1.1.5 (development)
+# ggpattern 1.2.0 (development)
+
+## New features
+
+* Adds `guide` argument to `scale_pattern_angle_discrete()`, `scale_pattern_density_discrete()`, `scale_pattern_spacing_discrete()`, `scale_pattern_xoffset_discrete()`, `scale_pattern_yoffset_discrete()`, `scale_pattern_aspect_ratio_discrete()`, `scale_pattern_key_scale_factor_discrete()`, `scale_pattern_scale_discrete()`, `scale_pattern_phase_discrete()`, `scale_pattern_frequency_discrete()`, `scale_pattern_res_discrete()`, `scale_pattern_rot_discrete()` (#139).
 
 ## Bug fixes and minor improvements
 

--- a/R/scale-pattern-auto.R
+++ b/R/scale-pattern-auto.R
@@ -230,7 +230,7 @@ scale_pattern_angle_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_angle_discrete <- function(..., range = c(0, 90)) {
+scale_pattern_angle_discrete <- function(..., range = c(0, 90), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -240,7 +240,7 @@ scale_pattern_angle_discrete <- function(..., range = c(0, 90)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_angle',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -284,7 +284,7 @@ scale_pattern_density_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_density_discrete <- function(..., range = c(0, 0.5)) {
+scale_pattern_density_discrete <- function(..., range = c(0, 0.5), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -294,7 +294,7 @@ scale_pattern_density_discrete <- function(..., range = c(0, 0.5)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_density',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -338,7 +338,7 @@ scale_pattern_spacing_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_spacing_discrete <- function(..., range = c(0.01, 0.1)) {
+scale_pattern_spacing_discrete <- function(..., range = c(0.01, 0.1), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -348,7 +348,7 @@ scale_pattern_spacing_discrete <- function(..., range = c(0.01, 0.1)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_spacing',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -392,7 +392,7 @@ scale_pattern_xoffset_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_xoffset_discrete <- function(..., range = c(0.01, 0.1)) {
+scale_pattern_xoffset_discrete <- function(..., range = c(0.01, 0.1), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -402,7 +402,7 @@ scale_pattern_xoffset_discrete <- function(..., range = c(0.01, 0.1)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_xoffset',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -446,7 +446,7 @@ scale_pattern_yoffset_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_yoffset_discrete <- function(..., range = c(0.01, 0.1)) {
+scale_pattern_yoffset_discrete <- function(..., range = c(0.01, 0.1), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -456,7 +456,7 @@ scale_pattern_yoffset_discrete <- function(..., range = c(0.01, 0.1)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_yoffset',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -500,7 +500,7 @@ scale_pattern_aspect_ratio_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_aspect_ratio_discrete <- function(..., range = c(0.5, 2)) {
+scale_pattern_aspect_ratio_discrete <- function(..., range = c(0.5, 2), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -510,7 +510,7 @@ scale_pattern_aspect_ratio_discrete <- function(..., range = c(0.5, 2)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_aspect_ratio',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -554,7 +554,7 @@ scale_pattern_key_scale_factor_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_key_scale_factor_discrete <- function(..., range = c(0.5, 2)) {
+scale_pattern_key_scale_factor_discrete <- function(..., range = c(0.5, 2), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -564,7 +564,7 @@ scale_pattern_key_scale_factor_discrete <- function(..., range = c(0.5, 2)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_key_scale_factor',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -782,7 +782,7 @@ scale_pattern_scale_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_scale_discrete <- function(..., range = c(0.5, 2)) {
+scale_pattern_scale_discrete <- function(..., range = c(0.5, 2), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -792,7 +792,7 @@ scale_pattern_scale_discrete <- function(..., range = c(0.5, 2)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_scale',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -894,7 +894,7 @@ scale_pattern_phase_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_phase_discrete <- function(..., range = NULL) {
+scale_pattern_phase_discrete <- function(..., range = NULL, guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -904,7 +904,7 @@ scale_pattern_phase_discrete <- function(..., range = NULL) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_phase',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -948,7 +948,7 @@ scale_pattern_frequency_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_frequency_discrete <- function(..., range = NULL) {
+scale_pattern_frequency_discrete <- function(..., range = NULL, guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -958,7 +958,7 @@ scale_pattern_frequency_discrete <- function(..., range = NULL) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_frequency',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -1060,7 +1060,7 @@ scale_pattern_res_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_res_discrete <- function(..., range = NULL) {
+scale_pattern_res_discrete <- function(..., range = NULL, guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -1070,7 +1070,7 @@ scale_pattern_res_discrete <- function(..., range = NULL) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_res',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }
@@ -1114,7 +1114,7 @@ scale_pattern_rot_continuous <- function(name = waiver(),
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_pattern_rot_discrete <- function(..., range = c(0, 360)) {
+scale_pattern_rot_discrete <- function(..., range = c(0, 360), guide = 'legend') {
   force(range)
 
   if (is.null(range)) {
@@ -1124,7 +1124,7 @@ scale_pattern_rot_discrete <- function(..., range = c(0, 360)) {
   ggplot2::discrete_scale(
     aesthetics = 'pattern_rot',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }

--- a/data-raw/generate-scales-continuous-discrete.R
+++ b/data-raw/generate-scales-continuous-discrete.R
@@ -85,7 +85,7 @@ template_discrete_var_cont_aes <- "
 #' @rdname scale_continuous
 #' @export
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-scale_{aes_name}_discrete <- function(..., range = {scale_default}) {{
+scale_{aes_name}_discrete <- function(..., range = {scale_default}, guide = 'legend') {{
   force(range)
 
   if (is.null(range)) {{
@@ -95,7 +95,7 @@ scale_{aes_name}_discrete <- function(..., range = {scale_default}) {{
   ggplot2::discrete_scale(
     aesthetics = '{aes_name}',
     palette    = function(n) seq(range[1], range[2], length.out = n),
-    guide      = 'legend',
+    guide      = guide,
     ...
   )
 }}

--- a/man/scale_continuous.Rd
+++ b/man/scale_continuous.Rd
@@ -40,7 +40,7 @@ scale_pattern_angle_continuous(
   transform = "identity"
 )
 
-scale_pattern_angle_discrete(..., range = c(0, 90))
+scale_pattern_angle_discrete(..., range = c(0, 90), guide = "legend")
 
 scale_pattern_density_continuous(
   name = waiver(),
@@ -54,7 +54,7 @@ scale_pattern_density_continuous(
   transform = "identity"
 )
 
-scale_pattern_density_discrete(..., range = c(0, 0.5))
+scale_pattern_density_discrete(..., range = c(0, 0.5), guide = "legend")
 
 scale_pattern_spacing_continuous(
   name = waiver(),
@@ -68,7 +68,7 @@ scale_pattern_spacing_continuous(
   transform = "identity"
 )
 
-scale_pattern_spacing_discrete(..., range = c(0.01, 0.1))
+scale_pattern_spacing_discrete(..., range = c(0.01, 0.1), guide = "legend")
 
 scale_pattern_xoffset_continuous(
   name = waiver(),
@@ -82,7 +82,7 @@ scale_pattern_xoffset_continuous(
   transform = "identity"
 )
 
-scale_pattern_xoffset_discrete(..., range = c(0.01, 0.1))
+scale_pattern_xoffset_discrete(..., range = c(0.01, 0.1), guide = "legend")
 
 scale_pattern_yoffset_continuous(
   name = waiver(),
@@ -96,7 +96,7 @@ scale_pattern_yoffset_continuous(
   transform = "identity"
 )
 
-scale_pattern_yoffset_discrete(..., range = c(0.01, 0.1))
+scale_pattern_yoffset_discrete(..., range = c(0.01, 0.1), guide = "legend")
 
 scale_pattern_aspect_ratio_continuous(
   name = waiver(),
@@ -110,7 +110,7 @@ scale_pattern_aspect_ratio_continuous(
   transform = "identity"
 )
 
-scale_pattern_aspect_ratio_discrete(..., range = c(0.5, 2))
+scale_pattern_aspect_ratio_discrete(..., range = c(0.5, 2), guide = "legend")
 
 scale_pattern_key_scale_factor_continuous(
   name = waiver(),
@@ -124,7 +124,11 @@ scale_pattern_key_scale_factor_continuous(
   transform = "identity"
 )
 
-scale_pattern_key_scale_factor_discrete(..., range = c(0.5, 2))
+scale_pattern_key_scale_factor_discrete(
+  ...,
+  range = c(0.5, 2),
+  guide = "legend"
+)
 
 scale_pattern_scale_continuous(
   name = waiver(),
@@ -138,7 +142,7 @@ scale_pattern_scale_continuous(
   transform = "identity"
 )
 
-scale_pattern_scale_discrete(..., range = c(0.5, 2))
+scale_pattern_scale_discrete(..., range = c(0.5, 2), guide = "legend")
 
 scale_pattern_phase_continuous(
   name = waiver(),
@@ -152,7 +156,7 @@ scale_pattern_phase_continuous(
   transform = "identity"
 )
 
-scale_pattern_phase_discrete(..., range = NULL)
+scale_pattern_phase_discrete(..., range = NULL, guide = "legend")
 
 scale_pattern_frequency_continuous(
   name = waiver(),
@@ -166,7 +170,7 @@ scale_pattern_frequency_continuous(
   transform = "identity"
 )
 
-scale_pattern_frequency_discrete(..., range = NULL)
+scale_pattern_frequency_discrete(..., range = NULL, guide = "legend")
 
 scale_pattern_res_continuous(
   name = waiver(),
@@ -180,7 +184,7 @@ scale_pattern_res_continuous(
   transform = "identity"
 )
 
-scale_pattern_res_discrete(..., range = NULL)
+scale_pattern_res_discrete(..., range = NULL, guide = "legend")
 
 scale_pattern_rot_continuous(
   name = waiver(),
@@ -194,7 +198,7 @@ scale_pattern_rot_continuous(
   transform = "identity"
 )
 
-scale_pattern_rot_discrete(..., range = c(0, 360))
+scale_pattern_rot_discrete(..., range = c(0, 360), guide = "legend")
 }
 \arguments{
 \item{name, breaks, labels, limits, range, trans, guide, ..., transform}{See


### PR DESCRIPTION
* Adds `guide` argument to `scale_pattern_angle_discrete()`, `scale_pattern_density_discrete()`, `scale_pattern_spacing_discrete()`, `scale_pattern_xoffset_discrete()`, `scale_pattern_yoffset_discrete()`, `scale_pattern_aspect_ratio_discrete()`, `scale_pattern_key_scale_factor_discrete()`, `scale_pattern_scale_discrete()`, `scale_pattern_phase_discrete()`, `scale_pattern_frequency_discrete()`, `scale_pattern_res_discrete()`, `scale_pattern_rot_discrete()` (#139).

closes #139